### PR TITLE
Remove yo as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
   },
   "devDependencies": {
     "mocha": "*"
-  },
-  "peerDependencies": {
-    "yo": ">=1.0.0"
   }
 }


### PR DESCRIPTION
Peer dependencies are gone with npm 3.

See https://twitter.com/Vaxilart/status/666698958975148033

This might confuse people using npm 3:
![screenshot](http://f.cl.ly/items/2k3z2V453V2h112J2w3v/steroids.png)