### PR TITLE
Update grunt-steroids in generated package.json

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {},
   "devDependencies": {
-    "grunt-steroids": "1.x"
+    "grunt-steroids": "^1.2.0"
   }
 }


### PR DESCRIPTION
The version of `grunt-steroids` was pinned to `1.x` in the generated `package.json`.

I replaced the pinned version with `^1.2.0`.
